### PR TITLE
MsBuild should be aware of version prefix and suffix

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -137,7 +137,7 @@ let vsProjProps = [
 
 Target "Clean" (fun _ ->
     !! solutionFile |> MSBuildReleaseExt "" vsProjProps "Clean" |> ignore
-    CleanDirs ["bin"; "temp"; "docs"]
+    CleanDirs ["bin"; "temp"; "docs"; (sprintf "src/%s/bin" project); (sprintf "src/%s/obj" project) ]
 )
 
 // --------------------------------------------------------------------------------------

--- a/build.fsx
+++ b/build.fsx
@@ -176,7 +176,7 @@ Target "NuGet" (fun _ ->
 )
 
 Target "CopyNuGet" (fun _ ->
-    !! ("src" </> project </> "bin" </> configuration </> (sprintf "%s*.nupkg" project))
+    !! ("src" </> project </> "bin" </> "**" </> configuration </> (sprintf "%s*.nupkg" project))
     |> CopyTo "bin"
 )
 

--- a/build.fsx
+++ b/build.fsx
@@ -137,7 +137,7 @@ let vsProjProps = [
 
 Target "Clean" (fun _ ->
     !! solutionFile |> MSBuildReleaseExt "" vsProjProps "Clean" |> ignore
-    CleanDirs ["bin"; "temp"; "docs"; (sprintf "src/%s/bin" project); (sprintf "src/%s/obj" project) ]
+    CleanDirs ["bin"; "temp"; "docs"; "src"</>project</>"bin"; "src"</>project</>"obj" ]
 )
 
 // --------------------------------------------------------------------------------------
@@ -362,7 +362,8 @@ Target "BuildPackage" DoNothing
 
 Target "All" DoNothing
 
-"AssemblyInfo"
+"Clean"
+  ==> "AssemblyInfo"
   ==> "Restore"
   ==> "Build"
   ==> "CopyBinaries"

--- a/build.fsx
+++ b/build.fsx
@@ -170,9 +170,14 @@ Target "RunTests" (fun _ ->
 // Build a NuGet package
 
 Target "NuGet" (fun _ ->
-  !! (sprintf "src/%s/%s.fsproj" project project)
-  |> MSBuildReleaseExt "bin" vsProjProps "pack"
+  !! ("src" </> project </> (sprintf "%s.fsproj" project))
+  |> MSBuildReleaseExt "" vsProjProps "pack"
   |> ignore
+)
+
+Target "CopyNuGet" (fun _ ->
+    !! ("src" </> project </> "bin" </> configuration </> (sprintf "%s*.nupkg" project))
+    |> CopyTo "bin"
 )
 
 Target "PublishNuget" (fun _ ->
@@ -365,6 +370,7 @@ Target "All" DoNothing
   ==> "GenerateReferenceDocs"
   ==> "GenerateDocs"
   ==> "NuGet"
+  ==> "CopyNuGet"
   ==> "BuildPackage"
   ==> "All"
 


### PR DESCRIPTION
Mainly to be able to get more reproducible builds locally

- Clean up folders before compiling anything
- Set version and version prefix in variables so that it gets set to correct versions when building
- Build using msbuild instead of dotnet (this helps when building on other OS's than Windows)