### PR TITLE
Shouldn't it use the default name for map?

### DIFF
--- a/docsrc/content/abstraction-functor.fsx
+++ b/docsrc/content/abstraction-functor.fsx
@@ -41,7 +41,7 @@ Rules
 *)
 (**
     map id  =  id
-    map (f << g) = map f << fmap g
+    map (f << g) = map f << map g
 *)
 (**
 


### PR DESCRIPTION
as I understand `fmap` is part of Haskell compatibility