### PR TITLE
Wrapper types as structs

### DIFF
--- a/src/FSharpPlus/Cont.fs
+++ b/src/FSharpPlus/Cont.fs
@@ -3,6 +3,7 @@
 /// <summary> Computation type: Computations which can be interrupted and resumed.
 /// <para/>   Binding strategy: Binding a function to a monadic value creates a new continuation which uses the function as the continuation of the monadic computation.
 /// <para/>   Useful for: Complex control structures, error handling, and creating co-routines.</summary>
+[<Struct>]
 type Cont<'r,'t> = Cont of (('t->'r)->'r)
 
 /// Basic operations on Cont

--- a/src/FSharpPlus/Error.fs
+++ b/src/FSharpPlus/Error.fs
@@ -26,6 +26,7 @@ module ResultOrException =
 
 
 /// Monad Transformer for Result<'T, 'E>
+[<Struct>]
 type ResultT<'``monad<'result<'t,'e>>``> = ResultT of '``monad<'result<'t,'e>>``
 
 /// Basic operations on ResultT

--- a/src/FSharpPlus/Foldable.fs
+++ b/src/FSharpPlus/Foldable.fs
@@ -7,6 +7,7 @@ namespace FSharpPlus.Internals
 open FSharpPlus.Control
 
 
+[<Struct>]
 type _Dual<'T> =
     struct
         val Value : 'T
@@ -15,6 +16,7 @@ type _Dual<'T> =
     static member inline get_Zero() = _Dual(Zero.Invoke())                                      : _Dual<'m>
     static member inline (+) (x: _Dual<'m>, y: _Dual<'m>) = _Dual (Plus.Invoke y.Value x.Value) : _Dual<'m>
 
+[<Struct>]
 type _Endo<'T> =
     struct
         val Value : 'T -> 'T

--- a/src/FSharpPlus/Identity.fs
+++ b/src/FSharpPlus/Identity.fs
@@ -10,6 +10,7 @@
 ///           The purpose of the Identity monad is its fundamental role in the theory of monad transformers.
 ///           Any monad transformer applied to the Identity monad yields a non-transformer version of that monad.
 ///           Its applicative instance plays a fundamental role in Lens. </summary> 
+[<Struct>]
 type Identity<'t> = Identity of 't with
     static member Return x = Identity x                                             : Identity<'T>
     static member Bind  (Identity x, f :'T -> Identity<'U>) = f x                   : Identity<'U>

--- a/src/FSharpPlus/Kleisli.fs
+++ b/src/FSharpPlus/Kleisli.fs
@@ -4,7 +4,7 @@ open FSharpPlus
 open FSharpPlus.Control
 
 /// Kleisli arrows of a monad. Represents a function 'T -> 'Monad<'U>
-[<NoEquality; NoComparison>]
+[<Struct; NoEquality; NoComparison>]
 type Kleisli<'t, '``monad<'u>``> = Kleisli of ('t -> '``monad<'u>``) with
 
     // Profunctor

--- a/src/FSharpPlus/Lens.fs
+++ b/src/FSharpPlus/Lens.fs
@@ -12,6 +12,8 @@ module Lens =
         let rmap' cd p = p >> cd
         let getAny (Any p) = p
         let getAll (All p) = p
+
+        [<Struct>]
         type Exchange<'T,'U> = Exchange of 'T * 'U with
             static member Dimap (Exchange (sa, bt), f, g) = Exchange (sa << f, g << bt)
 

--- a/src/FSharpPlus/List.fs
+++ b/src/FSharpPlus/List.fs
@@ -30,6 +30,7 @@ module List =
 open FSharpPlus.Control
 
 /// Monad Transformer for list<'T>
+[<Struct>]
 type ListT<'``monad<list<'t>>``> = ListT of '``monad<list<'t>>``
 
 /// Basic operations on ListT

--- a/src/FSharpPlus/Monoids.fs
+++ b/src/FSharpPlus/Monoids.fs
@@ -3,6 +3,7 @@
 open FSharpPlus.Operators
 
 /// The dual of a monoid, obtained by swapping the arguments of append.
+[<Struct>]
 type Dual<'t> = Dual of 't with
     static member inline get_Zero () = Dual (getZero ())        : Dual<'T>
     static member inline (+) (Dual x, Dual y) = Dual (plus y x) : Dual<'T>
@@ -12,7 +13,7 @@ type Dual<'t> = Dual of 't with
 module Dual = let run (Dual x) = x          : 'T
 
 /// The monoid of endomorphisms under composition.
-[<NoEquality; NoComparison>]
+[<Struct; NoEquality; NoComparison>]
 type Endo<'t> = Endo of ('t -> 't) with
     static member get_Zero () = Endo id                : Endo<'T>
     static member (+) (Endo f, Endo g) = Endo (f << g) : Endo<'T>
@@ -23,11 +24,13 @@ module Endo = let run (Endo f) = f : 'T -> 'T
 
 
 /// Boolean monoid under conjunction.
+[<Struct>]
 type All = All of bool with
     static member Zero = All true
     static member (+) (All x, All y) = All (x && y)
 
 /// Boolean monoid under disjunction.
+[<Struct>]
 type Any = Any of bool with
     static member Zero = Any false
     static member (+) (Any x, Any y) = Any (x || y)
@@ -36,6 +39,7 @@ type Any = Any of bool with
 /// <summary> The Const functor, defined as Const&lt;&#39;T, &#39;U&gt; where &#39;U is a phantom type. Useful for: Lens getters Its applicative instance plays a fundamental role in Lens.
 /// <para/>   Useful for: Lens getters.
 /// <para/>   Its applicative instance plays a fundamental role in Lens. </summary>
+[<Struct>]
 type Const<'t,'u> = Const of 't with
 
     // Monoid
@@ -63,12 +67,14 @@ module Const =
 
 
 /// Option<'T> monoid returning the leftmost non-None value.
+[<Struct>]
 type First<'t> = First of Option<'t> with
     static member get_Zero () = First None                                    : First<'t>
     static member (+) (x, y) = match x, y with First None, r -> r | l, _ -> l : First<'t>
     static member run (First a) = a                                           : 't option
 
 /// Option<'T> monoid returning the rightmost non-None value.
+[<Struct>]
 type Last<'t> = Last of Option<'t> with
     static member get_Zero () = Last None                                     : Last<'t>
     static member (+) (x, y) = match x, y with l, Last None -> l | _, r -> r  : Last<'t>
@@ -76,12 +82,14 @@ type Last<'t> = Last of Option<'t> with
 
 
 /// Numeric wrapper for multiplication monoid (*, 1)
+[<Struct>]
 type Mult<'a> = Mult of 'a with
     static member inline get_Zero () = Mult one
     static member inline (+) (Mult (x:'n), Mult (y:'n)) = Mult (x * y)
 
 
 /// Right-to-left composition of functors. The composition of applicative functors is always applicative, but the composition of monads is not always a monad.
+[<Struct>]
 type Compose<'``f<'g<'t>>``> = Compose of '``f<'g<'t>>`` with
 
     // Functor

--- a/src/FSharpPlus/Option.fs
+++ b/src/FSharpPlus/Option.fs
@@ -10,6 +10,7 @@ module Option =
 
 
 /// Monad Transformer for Option<'T>
+[<Struct>]
 type OptionT<'``monad<option<'t>>``> = OptionT of '``monad<option<'t>>``
 
 /// Basic operations on OptionT

--- a/src/FSharpPlus/Reader.fs
+++ b/src/FSharpPlus/Reader.fs
@@ -6,6 +6,7 @@ open FSharpPlus.Control
 /// <summary> Computation type: Computations which read values from a shared environment.
 /// <para/>   Binding strategy: Monad values are functions from the environment to a value. The bound function is applied to the bound value, and both have access to the shared environment.
 /// <para/>   Useful for: Maintaining variable bindings, or other shared environment.</summary>
+[<Struct>]
 type Reader<'r,'t> = Reader of ('r->'t)
 
 /// Basic operations on Reader
@@ -38,6 +39,7 @@ type Reader<'r,'t> with
 
 
 /// Monad Transformer for Reader<'R, 'T>
+[<Struct>]
 type ReaderT<'r,'``monad<'t>``> = ReaderT of ('r -> '``monad<'t>``)
 
 /// Basic operations on Reader

--- a/src/FSharpPlus/Seq.fs
+++ b/src/FSharpPlus/Seq.fs
@@ -13,6 +13,7 @@ module Seq =
 
 
 /// Monad Transformer for seq<'T>
+[<Struct>]
 type SeqT<'``monad<seq<'t>>``> = SeqT of '``monad<seq<'t>>``
 
 /// Basic operations on SeqT

--- a/src/FSharpPlus/State.fs
+++ b/src/FSharpPlus/State.fs
@@ -3,6 +3,7 @@
 /// <summary> Computation type: Computations which maintain state.
 /// <para/>   Binding strategy: Threads a state parameter through the sequence of bound functions so that the same state value is never used twice, giving the illusion of in-place update.
 /// <para/>   Useful for: Building computations from sequences of operations that require a shared state. </summary>
+[<Struct>]
 type State<'s,'t> = State of ('s->('t * 's))
 
 /// Basic operations on State
@@ -34,6 +35,7 @@ open FSharpPlus.Control
 open FSharpPlus
 
 /// Monad Transformer for State<'S, 'T>
+[<Struct>]
 type StateT<'s,'``monad<'t * 's>``> = StateT of ('s -> '``monad<'t * 's>``)
 
 /// Basic operations on StateT

--- a/src/FSharpPlus/Writer.fs
+++ b/src/FSharpPlus/Writer.fs
@@ -3,6 +3,7 @@
 /// <summary> Computation type: Computations which produce a stream of data in addition to the computed values.
 /// <para/>   Binding strategy: Combines the outputs of the subcomputations using <c>mappend</c>.
 /// <para/>   Useful for: Logging, or other computations that produce output "on the side". </summary>
+[<Struct>]
 type Writer<'monoid,'t> = Writer of ('t * 'monoid)
 
 open FSharpPlus
@@ -48,6 +49,7 @@ type Writer<'monoid,'t> with
 open FSharpPlus.Control
 
 /// Monad Transformer for Writer<'Monoid, 'T>
+[<Struct>]
 type WriterT<'``monad<'t * 'monoid>``> = WriterT of '``monad<'t * 'monoid>``
 
 /// Basic operations on WriterT


### PR DESCRIPTION
Operations like ``bind`` make heavy use of wrapping-unwrapping. In order to avoid additional pressure on the GC we can set all wrapper types to structs.