### PR TITLE
Moving parse DateTime to separate test

### DIFF
--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -1021,11 +1021,18 @@ module Splits =
 
 module Parsing = 
     [<Test>]
+    let parseDateTime() =
+#if MONO
+        let v1 : DateTime = parse "2011-03-04T15:42:19+03:00"
+        Assert.IsTrue((v1 = DateTime(2011,3,4,12,42,19)))
+#else
+        Assert.Ignore("Depends on how it's executed...")
+#endif
+
+    [<Test>]
     let parse() = 
-        let v1 : DateTime       = parse "2011-03-04T15:42:19+03:00"
         let v2 : DateTimeOffset = parse "2011-03-04T15:42:19+03:00"
 
-        Assert.IsTrue((v1 = DateTime(2011,3,4,12,42,19)))
         Assert.IsTrue((v2 = DateTimeOffset(2011,3,4,15,42,19, TimeSpan.FromHours 3.)))
 
         let r101 = tryParse "10.1.0.1" : Net.IPAddress option


### PR DESCRIPTION
Trouble is that parsing DateTime depends on machine configuration and how the tests are executed.
When using F#+ and executing the tests in [a repository](https://github.com/wallymathieu/DateTimeBehaviorOnTravisAndAppveyor) based on the MiniScaffold template we notice that the behavior is consistent. While executing using NUnit2 test runner on mono Mac OS X, mono on Linux image on Travis and .net on Windows image on Appveyor gives different behaviors.
In order to not to fix something in F#+ for which there is a library that [solves DateTime issues](https://github.com/nodatime/nodatime/), better to ignore the discrepancies. 