### PR TITLE
In order to avoid confusing intellisense

### DIFF
--- a/src/FSharpPlus/Cont.fs
+++ b/src/FSharpPlus/Cont.fs
@@ -1,4 +1,5 @@
 ﻿namespace FSharpPlus.Data
+open System.ComponentModel
 
 /// <summary> Computation type: Computations which can be interrupted and resumed.
 /// <para/>   Binding strategy: Binding a function to a monadic value creates a new continuation which uses the function as the continuation of the monadic computation.
@@ -24,25 +25,39 @@ open FSharpPlus
 type ContT<'r,'t> = Cont<'r,'t>
 
 type Cont<'r,'t> with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return n = Cont (fun k -> k n)                        : Cont<'R,'T>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map    (x : Cont<'R,'T>, f) = Cont.map f x            : Cont<'R,'U>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (<*>)  (f, x : Cont<'R,'T>) = Cont.apply f x          : Cont<'R,'U>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (>>=)  (x, f : 'T->_)       = Cont.bind f x           : Cont<'R,'U>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Delay f = Cont (fun k -> Cont.run (f()) k)            : Cont<'R,'T>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member TryWith    (Cont c, h) = Cont(fun k -> try (c k) with e -> Cont.run (h e) k) : Cont<'R,'T>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member TryFinally (Cont c, h) = Cont(fun k -> try (c k) finally h())                : Cont<'R,'T>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member CallCC (f: ('T -> Cont<'R,'U>) -> _) = Cont.callCC f  : Cont<'R,'T>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (m:'``Monad<'T>``) = Cont ((>>=) m) : ContT<'``Monad<'R>``,'T>    
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline LiftAsync (x: Async<'T>) = lift (liftAsync x) : ContT<Async<'R>,'T>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Ask () = lift ask              : '``ContT<'MonadReader<'R,'T>,'R>``
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Local (Cont m, f : 'R1 -> 'R2)     : ContT<_,'``MonadReader<R1,'T>,'U``> =
         Cont <| fun c -> (ask >>= (fun r -> local f (m (local (konst r) << c))))
     
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Get () = lift get         : '``ContT<'MonadState<'S, 'T>, 'S>``
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'S) = x |> put |> lift : '``ContT<'MonadState<'S, 'T>, unit>``
 
 /// Basic operations on ContT

--- a/src/FSharpPlus/Cont.fs
+++ b/src/FSharpPlus/Cont.fs
@@ -29,9 +29,7 @@ type Cont<'r,'t> with
     static member Return n = Cont (fun k -> k n)                        : Cont<'R,'T>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map    (x : Cont<'R,'T>, f) = Cont.map f x            : Cont<'R,'U>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (<*>)  (f, x : Cont<'R,'T>) = Cont.apply f x          : Cont<'R,'U>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (>>=)  (x, f : 'T->_)       = Cont.bind f x           : Cont<'R,'U>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Delay f = Cont (fun k -> Cont.run (f()) k)            : Cont<'R,'T>
@@ -49,13 +47,11 @@ type Cont<'r,'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline LiftAsync (x: Async<'T>) = lift (liftAsync x) : ContT<Async<'R>,'T>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Ask () = lift ask              : '``ContT<'MonadReader<'R,'T>,'R>``
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Local (Cont m, f : 'R1 -> 'R2)     : ContT<_,'``MonadReader<R1,'T>,'U``> =
         Cont <| fun c -> (ask >>= (fun r -> local f (m (local (konst r) << c))))
     
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Get () = lift get         : '``ContT<'MonadState<'S, 'T>, 'S>``
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'S) = x |> put |> lift : '``ContT<'MonadState<'S, 'T>, unit>``

--- a/src/FSharpPlus/Cont.fs
+++ b/src/FSharpPlus/Cont.fs
@@ -25,35 +25,27 @@ open FSharpPlus
 type ContT<'r,'t> = Cont<'r,'t>
 
 type Cont<'r,'t> with
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return n = Cont (fun k -> k n)                        : Cont<'R,'T>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map    (x : Cont<'R,'T>, f) = Cont.map f x            : Cont<'R,'U>
     static member (<*>)  (f, x : Cont<'R,'T>) = Cont.apply f x          : Cont<'R,'U>
     static member (>>=)  (x, f : 'T->_)       = Cont.bind f x           : Cont<'R,'U>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Delay f = Cont (fun k -> Cont.run (f()) k)            : Cont<'R,'T>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member TryWith    (Cont c, h) = Cont(fun k -> try (c k) with e -> Cont.run (h e) k) : Cont<'R,'T>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member TryFinally (Cont c, h) = Cont(fun k -> try (c k) finally h())                : Cont<'R,'T>
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member CallCC (f: ('T -> Cont<'R,'U>) -> _) = Cont.callCC f  : Cont<'R,'T>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (m:'``Monad<'T>``) = Cont ((>>=) m) : ContT<'``Monad<'R>``,'T>    
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline LiftAsync (x: Async<'T>) = lift (liftAsync x) : ContT<Async<'R>,'T>
 
     static member inline get_Ask () = lift ask              : '``ContT<'MonadReader<'R,'T>,'R>``
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Local (Cont m, f : 'R1 -> 'R2)     : ContT<_,'``MonadReader<R1,'T>,'U``> =
         Cont <| fun c -> (ask >>= (fun r -> local f (m (local (konst r) << c))))
     
     static member inline get_Get () = lift get         : '``ContT<'MonadState<'S, 'T>, 'S>``
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'S) = x |> put |> lift : '``ContT<'MonadState<'S, 'T>, unit>``
 
 /// Basic operations on ContT

--- a/src/FSharpPlus/DList.fs
+++ b/src/FSharpPlus/DList.fs
@@ -239,13 +239,9 @@ module DList =
     let inline bind m k              = DList.foldBack (append << k) empty m
 type DList<'T> with
     
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member get_Zero = DList( 0, Nil)
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (+) (x:DList<_>, y:DList<_>) = DList.append x y
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member get_Empty = DList( 0, Nil)
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (<|>) (x:DList<_>, y:DList<_>) = DList.append x y
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member ToSeq  x = DList.toSeq  x
@@ -260,7 +256,5 @@ type DList<'T> with
     static member Return x = DList (1, x)
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map (x, f) = DList.map f x
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (<*>) (f, x) = DList.ap f x
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (>>=) (x, f) = DList.bind x f

--- a/src/FSharpPlus/DList.fs
+++ b/src/FSharpPlus/DList.fs
@@ -1,6 +1,8 @@
 ﻿namespace FSharpPlus.Data
 open System.Collections.Generic
 open FSharpPlus
+open System.ComponentModel
+
 // DList from FSharpx.Collections
 //This implementation adds an additional parameter to allow O(1) retrieval of the list length.
 
@@ -235,21 +237,30 @@ module DList =
     let concat x = DList.fold append empty x 
     let inline ap f x = concat <| map (fun y -> map ((|>) y) f) x
     let inline bind m k              = DList.foldBack (append << k) empty m
-
 type DList<'T> with
     
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member get_Zero = DList( 0, Nil)
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (+) (x:DList<_>, y:DList<_>) = DList.append x y
-
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member get_Empty = DList( 0, Nil)
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (<|>) (x:DList<_>, y:DList<_>) = DList.append x y
-    
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member ToSeq  x = DList.toSeq  x
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member ToList x = DList.toList x
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member OfSeq  x = DList.ofSeq  x
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Fold (x, f, z) = DList.fold f x z
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return x = DList (1, x)
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map (x, f) = DList.map f x
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (<*>) (f, x) = DList.ap f x
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (>>=) (x, f) = DList.bind x f

--- a/src/FSharpPlus/DList.fs
+++ b/src/FSharpPlus/DList.fs
@@ -253,7 +253,7 @@ type DList<'T> with
     static member Fold (x, f, z) = DList.fold f x z
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
-    static member Return x = DList (1, x)
+    static member Return x = DList.singleton x
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map (x, f) = DList.map f x
     static member (<*>) (f, x) = DList.ap f x

--- a/src/FSharpPlus/Error.fs
+++ b/src/FSharpPlus/Error.fs
@@ -3,6 +3,8 @@
 open System
 open FSharpPlus.Control
 open FSharpPlus
+open System.ComponentModel
+
 
 /// Additional operations on Result
 [<RequireQualifiedAccess>]
@@ -38,29 +40,45 @@ module ResultT =
     let inline map  (f:'T->'U) (ResultT m:ResultT<'``Monad<'Result<'T,'E>>``>) = ResultT (map (Result.map f) m) :ResultT<'``Monad<'Result<('T -> 'U),'E>>``>
 
 type ResultT<'``monad<'result<'t,'e>>``> with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return (x : 'T) = ResultT (result (Ok x))                                                                            : ResultT<'``Monad<'Result<'T,'E>>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : ResultT<'``Monad<'Result<'T,'E>>``>, f : 'T->'U) = ResultT.map f x                                       : ResultT<'``Monad<'Result<'U,'E>>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>)  (f : ResultT<'``Monad<'Result<('T -> 'U),'E>>``>, x : ResultT<'``Monad<'Result<'T,'E>>``>) = ResultT.apply f x: ResultT<'``Monad<'Result<'U,'E>>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (>>=)  (x : ResultT<'``Monad<'Result<'T,'E>>``>, f : 'T->ResultT<'``Monad<'Result<'U,'E>>``>)     = ResultT.bind f x
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (x:'``Monad<'T>``) = x |> liftM Ok |> ResultT : ResultT<'``Monad<Result<'T,'E>>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Throw (x:'E) =  x |> Error |> result |> ResultT : ResultT<'``Monad<Result<'T,'E>>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Catch (ResultT x :ResultT<'``MonadError<'E1,'T>``>, f: 'E1 -> _) = (ResultT (x >>= (fun a -> match a with Error l -> ResultT.run (f l) | Ok r -> result (Ok r)))) : ResultT<'``Monad<Result<'T,'E2>>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline LiftAsync (x :Async<'T>) = lift (liftAsync x) : '``ResultT<'MonadAsync<'T>>``
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline CallCC (f:('T -> ResultT<'``MonadCont<'R,Result<'U,'E>>``>) -> _) :ResultT<'``MonadCont<'R, Result<'T,'E>>``> = ResultT(callCC <| fun c -> ResultT.run(f (ResultT << c << Ok)))
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Ask () = (ResultT << (map Ok)) ask : ResultT<'``MonadReader<'R,Result<'R,'E>>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Local (ResultT m : ResultT<'``MonadReader<'R2,Result<'R2,'E>>``>, f:'R1->'R2) = ResultT (local f m)
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Tell (w:'Monoid) = w |> tell |> lift : '``ResultT<Writer<'Monoid,Result<unit,'E>>>``
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Listen m : ResultT<'``MonadWriter<'Monoid,Result<'T*'Monoid,'E>>``> =
         let liftError (m, w) = Result.map (fun x -> (x, w)) m
         ResultT (listen (ResultT.run m) >>= (result << liftError))
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Pass m = ResultT (ResultT.run m >>= either (map Ok << pass << result) (result << Error)) : ResultT<'``MonadWriter<'Monoid,Result<'T,'E>>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Get()  = lift get         : '``ResultT<'MonadState<'S,Result<_,'E>>>``
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'S) = x |> put |> lift : '``ResultT<'MonadState<'S,Result<_,'E>>>``

--- a/src/FSharpPlus/Error.fs
+++ b/src/FSharpPlus/Error.fs
@@ -40,41 +40,30 @@ module ResultT =
     let inline map  (f:'T->'U) (ResultT m:ResultT<'``Monad<'Result<'T,'E>>``>) = ResultT (map (Result.map f) m) :ResultT<'``Monad<'Result<('T -> 'U),'E>>``>
 
 type ResultT<'``monad<'result<'t,'e>>``> with
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return (x : 'T) = ResultT (result (Ok x))                                                                            : ResultT<'``Monad<'Result<'T,'E>>``>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : ResultT<'``Monad<'Result<'T,'E>>``>, f : 'T->'U) = ResultT.map f x                                       : ResultT<'``Monad<'Result<'U,'E>>``>
     static member inline (<*>)  (f : ResultT<'``Monad<'Result<('T -> 'U),'E>>``>, x : ResultT<'``Monad<'Result<'T,'E>>``>) = ResultT.apply f x: ResultT<'``Monad<'Result<'U,'E>>``>
     static member inline (>>=)  (x : ResultT<'``Monad<'Result<'T,'E>>``>, f : 'T->ResultT<'``Monad<'Result<'U,'E>>``>)     = ResultT.bind f x
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (x:'``Monad<'T>``) = x |> liftM Ok |> ResultT : ResultT<'``Monad<Result<'T,'E>>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Throw (x:'E) =  x |> Error |> result |> ResultT : ResultT<'``Monad<Result<'T,'E>>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Catch (ResultT x :ResultT<'``MonadError<'E1,'T>``>, f: 'E1 -> _) = (ResultT (x >>= (fun a -> match a with Error l -> ResultT.run (f l) | Ok r -> result (Ok r)))) : ResultT<'``Monad<Result<'T,'E2>>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline LiftAsync (x :Async<'T>) = lift (liftAsync x) : '``ResultT<'MonadAsync<'T>>``
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline CallCC (f:('T -> ResultT<'``MonadCont<'R,Result<'U,'E>>``>) -> _) :ResultT<'``MonadCont<'R, Result<'T,'E>>``> = ResultT(callCC <| fun c -> ResultT.run(f (ResultT << c << Ok)))
 
     static member inline get_Ask () = (ResultT << (map Ok)) ask : ResultT<'``MonadReader<'R,Result<'R,'E>>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Local (ResultT m : ResultT<'``MonadReader<'R2,Result<'R2,'E>>``>, f:'R1->'R2) = ResultT (local f m)
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Tell (w:'Monoid) = w |> tell |> lift : '``ResultT<Writer<'Monoid,Result<unit,'E>>>``
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Listen m : ResultT<'``MonadWriter<'Monoid,Result<'T*'Monoid,'E>>``> =
         let liftError (m, w) = Result.map (fun x -> (x, w)) m
         ResultT (listen (ResultT.run m) >>= (result << liftError))
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Pass m = ResultT (ResultT.run m >>= either (map Ok << pass << result) (result << Error)) : ResultT<'``MonadWriter<'Monoid,Result<'T,'E>>``>
 
     static member inline get_Get()  = lift get         : '``ResultT<'MonadState<'S,Result<_,'E>>>``
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'S) = x |> put |> lift : '``ResultT<'MonadState<'S,Result<_,'E>>>``

--- a/src/FSharpPlus/Error.fs
+++ b/src/FSharpPlus/Error.fs
@@ -44,9 +44,7 @@ type ResultT<'``monad<'result<'t,'e>>``> with
     static member inline Return (x : 'T) = ResultT (result (Ok x))                                                                            : ResultT<'``Monad<'Result<'T,'E>>``>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : ResultT<'``Monad<'Result<'T,'E>>``>, f : 'T->'U) = ResultT.map f x                                       : ResultT<'``Monad<'Result<'U,'E>>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>)  (f : ResultT<'``Monad<'Result<('T -> 'U),'E>>``>, x : ResultT<'``Monad<'Result<'T,'E>>``>) = ResultT.apply f x: ResultT<'``Monad<'Result<'U,'E>>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (>>=)  (x : ResultT<'``Monad<'Result<'T,'E>>``>, f : 'T->ResultT<'``Monad<'Result<'U,'E>>``>)     = ResultT.bind f x
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
@@ -63,7 +61,6 @@ type ResultT<'``monad<'result<'t,'e>>``> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline CallCC (f:('T -> ResultT<'``MonadCont<'R,Result<'U,'E>>``>) -> _) :ResultT<'``MonadCont<'R, Result<'T,'E>>``> = ResultT(callCC <| fun c -> ResultT.run(f (ResultT << c << Ok)))
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Ask () = (ResultT << (map Ok)) ask : ResultT<'``MonadReader<'R,Result<'R,'E>>``>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Local (ResultT m : ResultT<'``MonadReader<'R2,Result<'R2,'E>>``>, f:'R1->'R2) = ResultT (local f m)
@@ -78,7 +75,6 @@ type ResultT<'``monad<'result<'t,'e>>``> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Pass m = ResultT (ResultT.run m >>= either (map Ok << pass << result) (result << Error)) : ResultT<'``MonadWriter<'Monoid,Result<'T,'E>>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Get()  = lift get         : '``ResultT<'MonadState<'S,Result<_,'E>>>``
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'S) = x |> put |> lift : '``ResultT<'MonadState<'S,Result<_,'E>>>``

--- a/src/FSharpPlus/Monoids.fs
+++ b/src/FSharpPlus/Monoids.fs
@@ -1,11 +1,14 @@
 ﻿namespace FSharpPlus.Data
 
 open FSharpPlus.Operators
+open System.ComponentModel
 
 /// The dual of a monoid, obtained by swapping the arguments of append.
 [<Struct>]
 type Dual<'t> = Dual of 't with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Zero () = Dual (getZero ())        : Dual<'T>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (+) (Dual x, Dual y) = Dual (plus y x) : Dual<'T>
 
 /// Basic operations on Dual
@@ -15,7 +18,9 @@ module Dual = let run (Dual x) = x          : 'T
 /// The monoid of endomorphisms under composition.
 [<Struct; NoEquality; NoComparison>]
 type Endo<'t> = Endo of ('t -> 't) with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member get_Zero () = Endo id                : Endo<'T>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (+) (Endo f, Endo g) = Endo (f << g) : Endo<'T>
 
 /// Basic operations on Endo
@@ -26,13 +31,17 @@ module Endo = let run (Endo f) = f : 'T -> 'T
 /// Boolean monoid under conjunction.
 [<Struct>]
 type All = All of bool with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Zero = All true
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (+) (All x, All y) = All (x && y)
 
 /// Boolean monoid under disjunction.
 [<Struct>]
 type Any = Any of bool with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Zero = Any false
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (+) (Any x, Any y) = Any (x || y)
 
 
@@ -43,21 +52,29 @@ type Any = Any of bool with
 type Const<'t,'u> = Const of 't with
 
     // Monoid
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Zero () = Const (getZero ()) : Const<'T,'U>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (+) (Const x : Const<'T,'U>, Const y : Const<'T,'U>) = Const (plus x y) : Const<'T,'U>
 
     // Functor
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map (Const x : Const<_,'T>, _:'T->'U) = Const x : Const<'C,'U>
 
     // Applicative
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return (_:'U) = Const (getZero ()) : Const<'T,'U>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>) (Const f : Const<'C,'T->'U>, Const x : Const<'C,'T>) = Const (plus f x) : Const<'C,'U>
 
     // Contravariant
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Contramap (Const x : Const<'C,'T>, _:'U->'T) = Const x     : Const<'C,'U>
 
     // Bifunctor
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member First     (Const x : Const<'T,'V>, f:'T->'U) = Const (f x) : Const<'U,'V>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Second    (Const x : Const<'T,'V>, _:'V->'W) = Const x     : Const<'T,'W>
 
 /// Basic operations on Const
@@ -69,22 +86,30 @@ module Const =
 /// Option<'T> monoid returning the leftmost non-None value.
 [<Struct>]
 type First<'t> = First of Option<'t> with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member get_Zero () = First None                                    : First<'t>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (+) (x, y) = match x, y with First None, r -> r | l, _ -> l : First<'t>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member run (First a) = a                                           : 't option
 
 /// Option<'T> monoid returning the rightmost non-None value.
 [<Struct>]
 type Last<'t> = Last of Option<'t> with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member get_Zero () = Last None                                     : Last<'t>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (+) (x, y) = match x, y with l, Last None -> l | _, r -> r  : Last<'t>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member run (Last a) = a                                            : 't option
 
 
 /// Numeric wrapper for multiplication monoid (*, 1)
 [<Struct>]
 type Mult<'a> = Mult of 'a with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Zero () = Mult one
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (+) (Mult (x:'n), Mult (y:'n)) = Mult (x * y)
 
 
@@ -93,14 +118,19 @@ type Mult<'a> = Mult of 'a with
 type Compose<'``f<'g<'t>>``> = Compose of '``f<'g<'t>>`` with
 
     // Functor
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map (Compose x, f:'T->'U) = Compose (map (map f) x)
 
     // Applicative
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return (x:'T) = Compose (result (result x)) : Compose<'``F<'G<'T>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>)  (Compose (f: '``F<'G<'T->'U>>``), Compose (x: '``F<'G<'T>>``)) = Compose ((<*>) <!> f <*> x: '``F<'G<'U>>``)
 
     // Alternative
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Empty ()                  = Compose (getEmpty ()) : Compose<'``F<'G<'T>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<|>) (Compose x, Compose y) = Compose (x <|> y)     : Compose<'``F<'G<'T>``>
 
 

--- a/src/FSharpPlus/Monoids.fs
+++ b/src/FSharpPlus/Monoids.fs
@@ -1,14 +1,11 @@
 ﻿namespace FSharpPlus.Data
 
 open FSharpPlus.Operators
-open System.ComponentModel
 
 /// The dual of a monoid, obtained by swapping the arguments of append.
 [<Struct>]
 type Dual<'t> = Dual of 't with
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Zero () = Dual (getZero ())        : Dual<'T>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (+) (Dual x, Dual y) = Dual (plus y x) : Dual<'T>
 
 /// Basic operations on Dual
@@ -18,9 +15,7 @@ module Dual = let run (Dual x) = x          : 'T
 /// The monoid of endomorphisms under composition.
 [<Struct; NoEquality; NoComparison>]
 type Endo<'t> = Endo of ('t -> 't) with
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member get_Zero () = Endo id                : Endo<'T>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (+) (Endo f, Endo g) = Endo (f << g) : Endo<'T>
 
 /// Basic operations on Endo
@@ -31,17 +26,13 @@ module Endo = let run (Endo f) = f : 'T -> 'T
 /// Boolean monoid under conjunction.
 [<Struct>]
 type All = All of bool with
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Zero = All true
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (+) (All x, All y) = All (x && y)
 
 /// Boolean monoid under disjunction.
 [<Struct>]
 type Any = Any of bool with
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Zero = Any false
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (+) (Any x, Any y) = Any (x || y)
 
 
@@ -52,29 +43,21 @@ type Any = Any of bool with
 type Const<'t,'u> = Const of 't with
 
     // Monoid
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Zero () = Const (getZero ()) : Const<'T,'U>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (+) (Const x : Const<'T,'U>, Const y : Const<'T,'U>) = Const (plus x y) : Const<'T,'U>
 
     // Functor
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map (Const x : Const<_,'T>, _:'T->'U) = Const x : Const<'C,'U>
 
     // Applicative
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return (_:'U) = Const (getZero ()) : Const<'T,'U>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>) (Const f : Const<'C,'T->'U>, Const x : Const<'C,'T>) = Const (plus f x) : Const<'C,'U>
 
     // Contravariant
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Contramap (Const x : Const<'C,'T>, _:'U->'T) = Const x     : Const<'C,'U>
 
     // Bifunctor
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member First     (Const x : Const<'T,'V>, f:'T->'U) = Const (f x) : Const<'U,'V>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Second    (Const x : Const<'T,'V>, _:'V->'W) = Const x     : Const<'T,'W>
 
 /// Basic operations on Const
@@ -86,30 +69,22 @@ module Const =
 /// Option<'T> monoid returning the leftmost non-None value.
 [<Struct>]
 type First<'t> = First of Option<'t> with
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member get_Zero () = First None                                    : First<'t>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (+) (x, y) = match x, y with First None, r -> r | l, _ -> l : First<'t>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member run (First a) = a                                           : 't option
 
 /// Option<'T> monoid returning the rightmost non-None value.
 [<Struct>]
 type Last<'t> = Last of Option<'t> with
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member get_Zero () = Last None                                     : Last<'t>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (+) (x, y) = match x, y with l, Last None -> l | _, r -> r  : Last<'t>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member run (Last a) = a                                            : 't option
 
 
 /// Numeric wrapper for multiplication monoid (*, 1)
 [<Struct>]
 type Mult<'a> = Mult of 'a with
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Zero () = Mult one
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (+) (Mult (x:'n), Mult (y:'n)) = Mult (x * y)
 
 
@@ -118,19 +93,14 @@ type Mult<'a> = Mult of 'a with
 type Compose<'``f<'g<'t>>``> = Compose of '``f<'g<'t>>`` with
 
     // Functor
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map (Compose x, f:'T->'U) = Compose (map (map f) x)
 
     // Applicative
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return (x:'T) = Compose (result (result x)) : Compose<'``F<'G<'T>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>)  (Compose (f: '``F<'G<'T->'U>>``), Compose (x: '``F<'G<'T>>``)) = Compose ((<*>) <!> f <*> x: '``F<'G<'U>>``)
 
     // Alternative
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Empty ()                  = Compose (getEmpty ()) : Compose<'``F<'G<'T>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<|>) (Compose x, Compose y) = Compose (x <|> y)     : Compose<'``F<'G<'T>``>
 
 

--- a/src/FSharpPlus/NonEmptyList.fs
+++ b/src/FSharpPlus/NonEmptyList.fs
@@ -41,7 +41,6 @@ type NonEmptyList<'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map (x:NonEmptyList<'a>, f:'a->'b) = NonEmptyList.map f x
         
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (>>=) ({Head = x; Tail = xs}, f:_->NonEmptyList<'b>  ) =
         let {Head = y; Tail = ys} = f x
         let ys' = List.collect (NonEmptyList.toList << f) xs
@@ -49,7 +48,6 @@ type NonEmptyList<'t> with
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return (x:'a) = {Head = x; Tail = []}
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (<*>)  (f:NonEmptyList<'T->'U>, x:NonEmptyList<'T>) = 
         let r = NonEmptyList.toList f <*> NonEmptyList.toList x
         {Head = r.Head; Tail = r.Tail}
@@ -58,11 +56,9 @@ type NonEmptyList<'t> with
     static member Extract    {Head = h; Tail = _} = h : 't
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Duplicate (s:NonEmptyList<'a>, [<Optional>]_impl:Duplicate) = NonEmptyList.tails s
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (=>>)     (s, g) = NonEmptyList.map g (NonEmptyList.tails s) :NonEmptyList<'b>
     
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (+) ({Head = h; Tail = t},  x) = {Head = h; Tail = t @ NonEmptyList.toList x}
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]

--- a/src/FSharpPlus/NonEmptyList.fs
+++ b/src/FSharpPlus/NonEmptyList.fs
@@ -2,6 +2,7 @@
 
 open System.Text
 open System.Runtime.InteropServices
+open System.ComponentModel
 open FSharpPlus.Control
 open FSharpPlus
 
@@ -37,32 +38,45 @@ module NonEmptyList =
         | h::t -> cons s (tails {Head = h; Tail = t})
          
 type NonEmptyList<'t> with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map (x:NonEmptyList<'a>, f:'a->'b) = NonEmptyList.map f x
         
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (>>=) ({Head = x; Tail = xs}, f:_->NonEmptyList<'b>  ) =
         let {Head = y; Tail = ys} = f x
         let ys' = List.collect (NonEmptyList.toList << f) xs
         {Head = y; Tail = (ys @ ys')}
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return (x:'a) = {Head = x; Tail = []}
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (<*>)  (f:NonEmptyList<'T->'U>, x:NonEmptyList<'T>) = 
         let r = NonEmptyList.toList f <*> NonEmptyList.toList x
         {Head = r.Head; Tail = r.Tail}
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Extract    {Head = h; Tail = _} = h : 't
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Duplicate (s:NonEmptyList<'a>, [<Optional>]_impl:Duplicate) = NonEmptyList.tails s
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (=>>)     (s, g) = NonEmptyList.map g (NonEmptyList.tails s) :NonEmptyList<'b>
     
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (+) ({Head = h; Tail = t},  x) = {Head = h; Tail = t @ NonEmptyList.toList x}
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member FoldBack ({Head = x; Tail = xs}, f, z) = List.foldBack f (x::xs) z
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member ToList   (s:NonEmptyList<'a>, [<Optional>]_impl:ToList) = NonEmptyList.toList s
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member ToSeq    (s:NonEmptyList<'a>, [<Optional>]_impl:ToSeq ) = NonEmptyList.toList s |> List.toSeq
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Traverse (s:NonEmptyList<'T>, f:'T->'``Functor<'U>``) =
         let lst = traverse f (toList s) : '``Functor<'List<'U>>``
         (NonEmptyList.create << List.head |> fun f x -> f x (List.tail x)) <!> lst : '``Functor<'NonEmptyList<'U>>``
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Replace (source:NonEmptyList<'T>, oldValue:NonEmptyList<'T>, newValue:NonEmptyList<'T>, _impl:Replace ) =
         let lst = source |> NonEmptyList.toSeq  |> Seq.replace oldValue newValue |> Seq.toList
         {Head = lst.Head; Tail = lst.Tail}

--- a/src/FSharpPlus/NonEmptyList.fs
+++ b/src/FSharpPlus/NonEmptyList.fs
@@ -46,33 +46,26 @@ type NonEmptyList<'t> with
         let ys' = List.collect (NonEmptyList.toList << f) xs
         {Head = y; Tail = (ys @ ys')}
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return (x:'a) = {Head = x; Tail = []}
     static member (<*>)  (f:NonEmptyList<'T->'U>, x:NonEmptyList<'T>) = 
         let r = NonEmptyList.toList f <*> NonEmptyList.toList x
         {Head = r.Head; Tail = r.Tail}
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Extract    {Head = h; Tail = _} = h : 't
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Duplicate (s:NonEmptyList<'a>, [<Optional>]_impl:Duplicate) = NonEmptyList.tails s
     static member (=>>)     (s, g) = NonEmptyList.map g (NonEmptyList.tails s) :NonEmptyList<'b>
     
 
     static member (+) ({Head = h; Tail = t},  x) = {Head = h; Tail = t @ NonEmptyList.toList x}
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member FoldBack ({Head = x; Tail = xs}, f, z) = List.foldBack f (x::xs) z
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member ToList   (s:NonEmptyList<'a>, [<Optional>]_impl:ToList) = NonEmptyList.toList s
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member ToSeq    (s:NonEmptyList<'a>, [<Optional>]_impl:ToSeq ) = NonEmptyList.toList s |> List.toSeq
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Traverse (s:NonEmptyList<'T>, f:'T->'``Functor<'U>``) =
         let lst = traverse f (toList s) : '``Functor<'List<'U>>``
         (NonEmptyList.create << List.head |> fun f x -> f x (List.tail x)) <!> lst : '``Functor<'NonEmptyList<'U>>``
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Replace (source:NonEmptyList<'T>, oldValue:NonEmptyList<'T>, newValue:NonEmptyList<'T>, _impl:Replace ) =
         let lst = source |> NonEmptyList.toSeq  |> Seq.replace oldValue newValue |> Seq.toList
         {Head = lst.Head; Tail = lst.Tail}

--- a/src/FSharpPlus/Option.fs
+++ b/src/FSharpPlus/Option.fs
@@ -2,6 +2,7 @@
 
 open FSharpPlus.Control
 open FSharpPlus
+open System.ComponentModel
 
 /// Additional operations on Option
 [<RequireQualifiedAccess>]
@@ -22,31 +23,49 @@ module OptionT =
     let inline map  (f:'T->'U) (OptionT m : OptionT<'``Monad<option<'T>``>)                                            = OptionT (map (Option.map f) m) : OptionT<'``Monad<option<'U>``>
 
 type OptionT<'``monad<option<'t>>``> with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return (x : 'T) = Some x |> result |> OptionT                                                         : OptionT<'``Monad<seq<'T>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : OptionT<'``Monad<seq<'T>``>, f : 'T->'U) = OptionT.map f x                                : OptionT<'``Monad<seq<'U>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>)  (f : OptionT<'``Monad<seq<('T -> 'U)>``>, x : OptionT<'``Monad<seq<'T>``>) = OptionT.apply f x : OptionT<'``Monad<seq<'U>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (>>=)  (x : OptionT<'``Monad<seq<'T>``>, f : 'T -> OptionT<'``Monad<seq<'U>``>)   = OptionT.bind  f x
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Empty () = OptionT <| result None : OptionT<'``MonadPlus<option<'T>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<|>) (OptionT x, OptionT y) = OptionT <| (x  >>= (fun maybe_value -> match maybe_value with Some _ -> x | _ -> y)) : OptionT<'``MonadPlus<option<'T>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (x:'``Monad<'T>``) = x |> liftM Some |> OptionT : OptionT<'``Monad<option<'T>>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline LiftAsync (x : Async<'T>) = lift (liftAsync x)  : '``OptionT<'MonadAsync<'T>>``
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Throw (x:'E) = x |> throw |> lift
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Catch (m:OptionT<'``MonadError<'E1,'T>``>, h:'E1 -> OptionT<'``MonadError<'E2,'T>``>) = OptionT ((fun v h -> catch v h) (OptionT.run m) (OptionT.run << h)) : OptionT<'``MonadError<'E2,'T>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline CallCC (f:(('T -> OptionT<'``MonadCont<'R,option<'U>>``>) -> _)) = OptionT(callCC <| fun c -> OptionT.run(f (OptionT << c << Some)))  : OptionT<'``MonadCont<'R,option<'T>>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Get() = lift get           : '``OptionT<'MonadState<'S,'S>>``
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'T) = x |> put |> lift  : '``OptionT<'MonadState<unit,'S>>``
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Ask() = lift ask                                                   :'``OptionT<'MonadReader<'R,option<'R>>>``
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Local (OptionT (m:'``MonadReader<'R2,'T>``), f:'R1->'R2) = OptionT (local f m)
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Tell (w:'Monoid) = w |> tell |> lift        : '``OptionT<'MonadWriter<'Monoid, unit>>``
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Listen (m )                                 : OptionT<'``'MonadWriter<'Monoid, option<'T>>``> =
         let liftMaybe (m, w) = Option.map (fun x -> (x, w)) m
         OptionT (listen (OptionT.run m) >>= (result << liftMaybe))
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Pass m : OptionT<'``MonadWriter<'Monoid, option<'T>>``> = OptionT (OptionT.run m >>= option (map Some << pass << result) (result None))

--- a/src/FSharpPlus/Option.fs
+++ b/src/FSharpPlus/Option.fs
@@ -27,14 +27,10 @@ type OptionT<'``monad<option<'t>>``> with
     static member inline Return (x : 'T) = Some x |> result |> OptionT                                                         : OptionT<'``Monad<seq<'T>``>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : OptionT<'``Monad<seq<'T>``>, f : 'T->'U) = OptionT.map f x                                : OptionT<'``Monad<seq<'U>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>)  (f : OptionT<'``Monad<seq<('T -> 'U)>``>, x : OptionT<'``Monad<seq<'T>``>) = OptionT.apply f x : OptionT<'``Monad<seq<'U>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (>>=)  (x : OptionT<'``Monad<seq<'T>``>, f : 'T -> OptionT<'``Monad<seq<'U>``>)   = OptionT.bind  f x
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Empty () = OptionT <| result None : OptionT<'``MonadPlus<option<'T>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<|>) (OptionT x, OptionT y) = OptionT <| (x  >>= (fun maybe_value -> match maybe_value with Some _ -> x | _ -> y)) : OptionT<'``MonadPlus<option<'T>``>
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
@@ -51,12 +47,10 @@ type OptionT<'``monad<option<'t>>``> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline CallCC (f:(('T -> OptionT<'``MonadCont<'R,option<'U>>``>) -> _)) = OptionT(callCC <| fun c -> OptionT.run(f (OptionT << c << Some)))  : OptionT<'``MonadCont<'R,option<'T>>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Get() = lift get           : '``OptionT<'MonadState<'S,'S>>``
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'T) = x |> put |> lift  : '``OptionT<'MonadState<unit,'S>>``
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Ask() = lift ask                                                   :'``OptionT<'MonadReader<'R,option<'R>>>``
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Local (OptionT (m:'``MonadReader<'R2,'T>``), f:'R1->'R2) = OptionT (local f m)

--- a/src/FSharpPlus/Option.fs
+++ b/src/FSharpPlus/Option.fs
@@ -23,7 +23,6 @@ module OptionT =
     let inline map  (f:'T->'U) (OptionT m : OptionT<'``Monad<option<'T>``>)                                            = OptionT (map (Option.map f) m) : OptionT<'``Monad<option<'U>``>
 
 type OptionT<'``monad<option<'t>>``> with
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return (x : 'T) = Some x |> result |> OptionT                                                         : OptionT<'``Monad<seq<'T>``>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : OptionT<'``Monad<seq<'T>``>, f : 'T->'U) = OptionT.map f x                                : OptionT<'``Monad<seq<'U>``>
@@ -33,33 +32,23 @@ type OptionT<'``monad<option<'t>>``> with
     static member inline get_Empty () = OptionT <| result None : OptionT<'``MonadPlus<option<'T>``>
     static member inline (<|>) (OptionT x, OptionT y) = OptionT <| (x  >>= (fun maybe_value -> match maybe_value with Some _ -> x | _ -> y)) : OptionT<'``MonadPlus<option<'T>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (x:'``Monad<'T>``) = x |> liftM Some |> OptionT : OptionT<'``Monad<option<'T>>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline LiftAsync (x : Async<'T>) = lift (liftAsync x)  : '``OptionT<'MonadAsync<'T>>``
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Throw (x:'E) = x |> throw |> lift
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Catch (m:OptionT<'``MonadError<'E1,'T>``>, h:'E1 -> OptionT<'``MonadError<'E2,'T>``>) = OptionT ((fun v h -> catch v h) (OptionT.run m) (OptionT.run << h)) : OptionT<'``MonadError<'E2,'T>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline CallCC (f:(('T -> OptionT<'``MonadCont<'R,option<'U>>``>) -> _)) = OptionT(callCC <| fun c -> OptionT.run(f (OptionT << c << Some)))  : OptionT<'``MonadCont<'R,option<'T>>``>
 
     static member inline get_Get() = lift get           : '``OptionT<'MonadState<'S,'S>>``
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'T) = x |> put |> lift  : '``OptionT<'MonadState<unit,'S>>``
 
     static member inline get_Ask() = lift ask                                                   :'``OptionT<'MonadReader<'R,option<'R>>>``
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Local (OptionT (m:'``MonadReader<'R2,'T>``), f:'R1->'R2) = OptionT (local f m)
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Tell (w:'Monoid) = w |> tell |> lift        : '``OptionT<'MonadWriter<'Monoid, unit>>``
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Listen (m )                                 : OptionT<'``'MonadWriter<'Monoid, option<'T>>``> =
         let liftMaybe (m, w) = Option.map (fun x -> (x, w)) m
         OptionT (listen (OptionT.run m) >>= (result << liftMaybe))
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Pass m : OptionT<'``MonadWriter<'Monoid, option<'T>>``> = OptionT (OptionT.run m >>= option (map Some << pass << result) (result None))

--- a/src/FSharpPlus/ParallelArray.fs
+++ b/src/FSharpPlus/ParallelArray.fs
@@ -44,9 +44,6 @@ type ParallelArray<'t> with
     static member Map (x:parray<_>, f) = ParallelArray.map f x
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return (x:'a) = Infinite x
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (<*>) (f:parray<'a->'b>, x:parray<_>) = ParallelArray.ap f x :parray<'b>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Zero() = Bounded (getZero()) : parray<'m>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (+) (x:parray<'m>, y:parray<'m>) = liftA2 plus x y:parray<'m>

--- a/src/FSharpPlus/ParallelArray.fs
+++ b/src/FSharpPlus/ParallelArray.fs
@@ -42,7 +42,6 @@ module ParallelArrayOperators =
 type ParallelArray<'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map (x:parray<_>, f) = ParallelArray.map f x
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return (x:'a) = Infinite x
     static member (<*>) (f:parray<'a->'b>, x:parray<_>) = ParallelArray.ap f x :parray<'b>
     static member inline get_Zero() = Bounded (getZero()) : parray<'m>

--- a/src/FSharpPlus/ParallelArray.fs
+++ b/src/FSharpPlus/ParallelArray.fs
@@ -2,6 +2,7 @@
 
 open FSharpPlus.Control
 open FSharpPlus.Operators
+open System.ComponentModel
 
 /// Array with an Applicative functor based on zipping and parallel execution.
 type ParallelArray<'t> =
@@ -39,8 +40,13 @@ module ParallelArrayOperators =
     let parray s = Bounded s
 
 type ParallelArray<'t> with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map (x:parray<_>, f) = ParallelArray.map f x
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return (x:'a) = Infinite x
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (<*>) (f:parray<'a->'b>, x:parray<_>) = ParallelArray.ap f x :parray<'b>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Zero() = Bounded (getZero()) : parray<'m>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (+) (x:parray<'m>, y:parray<'m>) = liftA2 plus x y:parray<'m>

--- a/src/FSharpPlus/Reader.fs
+++ b/src/FSharpPlus/Reader.fs
@@ -2,7 +2,7 @@
 
 open FSharpPlus
 open FSharpPlus.Control
-
+open System.ComponentModel
 /// <summary> Computation type: Computations which read values from a shared environment.
 /// <para/>   Binding strategy: Monad values are functions from the environment to a value. The bound function is applied to the bound value, and both have access to the shared environment.
 /// <para/>   Useful for: Maintaining variable bindings, or other shared environment.</summary>
@@ -26,15 +26,23 @@ module Reader =
     let local (f:'R1->'R2) m = let (Reader m) = m in Reader (m << f)      : Reader<'R1,'T>
 
 type Reader<'r,'t> with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map   (x:Reader<'R,'T>, f) = Reader.map f x   : Reader<'R,'U>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return x = Reader (fun _ -> x)                : Reader<'R,'T>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (>>=) (x:Reader<'R,'T>, f) = Reader.bind f x  : Reader<'R,'U>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (<*>) (f, x:Reader<'R,'T>) = Reader.apply f x : Reader<'R,'U>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member get_Ask()    = Reader.ask                     : Reader<'R,'R>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Local (m, f:'R1->'R2) = Reader.local f m      : Reader<'R1,'T>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Extract (Reader (f : 'Monoid -> 'T)) = f (Zero.Invoke()) : 'T
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (=>>)   (Reader (g : 'Monoid -> 'T), f : Reader<'Monoid,'T> -> 'U) = Reader (fun a -> f (Reader (fun b -> (g (Plus.Invoke a b))))) : Reader<'Monoid,'U>
 
 
@@ -51,35 +59,54 @@ module ReaderT =
     let inline bind  (f:'T->_) (ReaderT (m:_->'``Monad<'T>``)) = ReaderT (fun r -> m r >>= (fun a -> run (f a) r))             : ReaderT<'R, '``Monad<'U>``>
 
 type ReaderT<'r,'``monad<'t>``> with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return (x : 'T) = ReaderT (fun _ -> result x)                                                   : ReaderT<'R, '``Monad<'T>``> 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : ReaderT<'R, '``Monad<'T>``>, f : 'T->'U)                        = ReaderT.map   f x : ReaderT<'R, '``Monad<'U>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>)  (f : ReaderT<_,'``Monad<'T -> 'U>``>, x : ReaderT<_,'``Monad<'T>``>) = ReaderT.apply f x : ReaderT<'R, '``Monad<'U>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (>>=)  (x : ReaderT<_,'``Monad<'T>``>, f : 'T->ReaderT<'R,'``Monad<'U>``>)  = ReaderT.bind  f x : ReaderT<'R, '``Monad<'U>``>
     
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Empty () = ReaderT (fun _ -> getEmpty()) : ReaderT<'R, '``MonadPlus<'T>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<|>) (ReaderT m, ReaderT n) = ReaderT (fun r -> m r <|> n r) : ReaderT<'R, '``MonadPlus<'T>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        Lift m = ReaderT (fun _ -> m)                                  : ReaderT<'R,'``Monad<'T>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline LiftAsync (x: Async<'T>) = (lift (liftAsync x)                 : ReaderT<'R,'``MonadAsync<'T>``>)
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline CallCC (f : ('T -> ReaderT<'R, Cont<_,'U>>) -> _)              : ReaderT<'R,'``MonadCont<'C,'T>``> =
         ReaderT (fun r -> callCC <| fun c -> ReaderT.run (f (fun a -> ReaderT <| fun _ -> c a)) r)
             
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Ask() = ReaderT result                                     : ReaderT<'R,'``Monad<'T>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        Local (ReaderT m, f:_->'R2) = ReaderT(fun r -> m (f r))        : ReaderT<'R1,'``Monad<'T>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Throw (x:'E) = x |> throw |> lift : ReaderT<'R,'``MonadError<'E,'T>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Catch (m:ReaderT<'R,'``MonadError<'E1,'T>``>, h:'E1 -> _) = 
         ReaderT (fun s -> catch (ReaderT.run m s)   (fun e -> ReaderT.run (h e) s))     : ReaderT<'R,'``MonadError<'E2,'T>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Tell   w           = w |> tell |> lift                         : ReaderT<'R, '``MonadWriter<'Monoid,unit>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Listen (ReaderT m) = ReaderT (fun w -> listen (m w))           : ReaderT<'R, '``MonadWriter<'Monoid,'T*'Monoid>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Pass   (ReaderT m) = ReaderT (fun w -> pass   (m w))           : ReaderT<'R, '``MonadWriter<'Monoid,'T>``>   
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Get () = lift get         : ReaderT<'R, '``MonadState<'S, 'S>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put x      = x |> put |> lift : ReaderT<'R, '``MonadState<'S, unit>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Delay (f: unit -> ReaderT<'R,'``Monad<'T>``>) =
         ReaderT (fun s ->
             let d() = ReaderT.run (f()) s

--- a/src/FSharpPlus/Reader.fs
+++ b/src/FSharpPlus/Reader.fs
@@ -28,7 +28,6 @@ module Reader =
 type Reader<'r,'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map   (x:Reader<'R,'T>, f) = Reader.map f x   : Reader<'R,'U>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return x = Reader (fun _ -> x)                : Reader<'R,'T>
     static member (>>=) (x:Reader<'R,'T>, f) = Reader.bind f x  : Reader<'R,'U>
     static member (<*>) (f, x:Reader<'R,'T>) = Reader.apply f x : Reader<'R,'U>
@@ -37,7 +36,6 @@ type Reader<'r,'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Local (m, f:'R1->'R2) = Reader.local f m      : Reader<'R1,'T>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Extract (Reader (f : 'Monoid -> 'T)) = f (Zero.Invoke()) : 'T
     static member inline (=>>)   (Reader (g : 'Monoid -> 'T), f : Reader<'Monoid,'T> -> 'U) = Reader (fun a -> f (Reader (fun b -> (g (Plus.Invoke a b))))) : Reader<'Monoid,'U>
 
@@ -55,7 +53,6 @@ module ReaderT =
     let inline bind  (f:'T->_) (ReaderT (m:_->'``Monad<'T>``)) = ReaderT (fun r -> m r >>= (fun a -> run (f a) r))             : ReaderT<'R, '``Monad<'U>``>
 
 type ReaderT<'r,'``monad<'t>``> with
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return (x : 'T) = ReaderT (fun _ -> result x)                                                   : ReaderT<'R, '``Monad<'T>``> 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : ReaderT<'R, '``Monad<'T>``>, f : 'T->'U)                        = ReaderT.map   f x : ReaderT<'R, '``Monad<'U>``>
@@ -65,38 +62,27 @@ type ReaderT<'r,'``monad<'t>``> with
     static member inline get_Empty () = ReaderT (fun _ -> getEmpty()) : ReaderT<'R, '``MonadPlus<'T>``>
     static member inline (<|>) (ReaderT m, ReaderT n) = ReaderT (fun r -> m r <|> n r) : ReaderT<'R, '``MonadPlus<'T>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        Lift m = ReaderT (fun _ -> m)                                  : ReaderT<'R,'``Monad<'T>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline LiftAsync (x: Async<'T>) = (lift (liftAsync x)                 : ReaderT<'R,'``MonadAsync<'T>``>)
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline CallCC (f : ('T -> ReaderT<'R, Cont<_,'U>>) -> _)              : ReaderT<'R,'``MonadCont<'C,'T>``> =
         ReaderT (fun r -> callCC <| fun c -> ReaderT.run (f (fun a -> ReaderT <| fun _ -> c a)) r)
             
     static member inline get_Ask() = ReaderT result                                     : ReaderT<'R,'``Monad<'T>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        Local (ReaderT m, f:_->'R2) = ReaderT(fun r -> m (f r))        : ReaderT<'R1,'``Monad<'T>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Throw (x:'E) = x |> throw |> lift : ReaderT<'R,'``MonadError<'E,'T>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Catch (m:ReaderT<'R,'``MonadError<'E1,'T>``>, h:'E1 -> _) = 
         ReaderT (fun s -> catch (ReaderT.run m s)   (fun e -> ReaderT.run (h e) s))     : ReaderT<'R,'``MonadError<'E2,'T>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Tell   w           = w |> tell |> lift                         : ReaderT<'R, '``MonadWriter<'Monoid,unit>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Listen (ReaderT m) = ReaderT (fun w -> listen (m w))           : ReaderT<'R, '``MonadWriter<'Monoid,'T*'Monoid>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Pass   (ReaderT m) = ReaderT (fun w -> pass   (m w))           : ReaderT<'R, '``MonadWriter<'Monoid,'T>``>   
 
     static member inline get_Get () = lift get         : ReaderT<'R, '``MonadState<'S, 'S>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put x      = x |> put |> lift : ReaderT<'R, '``MonadState<'S, unit>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Delay (f: unit -> ReaderT<'R,'``Monad<'T>``>) =
         ReaderT (fun s ->
             let d() = ReaderT.run (f()) s

--- a/src/FSharpPlus/Reader.fs
+++ b/src/FSharpPlus/Reader.fs
@@ -30,19 +30,15 @@ type Reader<'r,'t> with
     static member Map   (x:Reader<'R,'T>, f) = Reader.map f x   : Reader<'R,'U>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return x = Reader (fun _ -> x)                : Reader<'R,'T>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (>>=) (x:Reader<'R,'T>, f) = Reader.bind f x  : Reader<'R,'U>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (<*>) (f, x:Reader<'R,'T>) = Reader.apply f x : Reader<'R,'U>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member get_Ask()    = Reader.ask                     : Reader<'R,'R>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Local (m, f:'R1->'R2) = Reader.local f m      : Reader<'R1,'T>
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Extract (Reader (f : 'Monoid -> 'T)) = f (Zero.Invoke()) : 'T
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (=>>)   (Reader (g : 'Monoid -> 'T), f : Reader<'Monoid,'T> -> 'U) = Reader (fun a -> f (Reader (fun b -> (g (Plus.Invoke a b))))) : Reader<'Monoid,'U>
 
 
@@ -63,14 +59,10 @@ type ReaderT<'r,'``monad<'t>``> with
     static member inline Return (x : 'T) = ReaderT (fun _ -> result x)                                                   : ReaderT<'R, '``Monad<'T>``> 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : ReaderT<'R, '``Monad<'T>``>, f : 'T->'U)                        = ReaderT.map   f x : ReaderT<'R, '``Monad<'U>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>)  (f : ReaderT<_,'``Monad<'T -> 'U>``>, x : ReaderT<_,'``Monad<'T>``>) = ReaderT.apply f x : ReaderT<'R, '``Monad<'U>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (>>=)  (x : ReaderT<_,'``Monad<'T>``>, f : 'T->ReaderT<'R,'``Monad<'U>``>)  = ReaderT.bind  f x : ReaderT<'R, '``Monad<'U>``>
     
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Empty () = ReaderT (fun _ -> getEmpty()) : ReaderT<'R, '``MonadPlus<'T>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<|>) (ReaderT m, ReaderT n) = ReaderT (fun r -> m r <|> n r) : ReaderT<'R, '``MonadPlus<'T>``>
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
@@ -83,7 +75,6 @@ type ReaderT<'r,'``monad<'t>``> with
     static member inline CallCC (f : ('T -> ReaderT<'R, Cont<_,'U>>) -> _)              : ReaderT<'R,'``MonadCont<'C,'T>``> =
         ReaderT (fun r -> callCC <| fun c -> ReaderT.run (f (fun a -> ReaderT <| fun _ -> c a)) r)
             
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Ask() = ReaderT result                                     : ReaderT<'R,'``Monad<'T>``>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        Local (ReaderT m, f:_->'R2) = ReaderT(fun r -> m (f r))        : ReaderT<'R1,'``Monad<'T>``>
@@ -101,7 +92,6 @@ type ReaderT<'r,'``monad<'t>``> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Pass   (ReaderT m) = ReaderT (fun w -> pass   (m w))           : ReaderT<'R, '``MonadWriter<'Monoid,'T>``>   
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Get () = lift get         : ReaderT<'R, '``MonadState<'S, 'S>``>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put x      = x |> put |> lift : ReaderT<'R, '``MonadState<'S, unit>``>

--- a/src/FSharpPlus/Seq.fs
+++ b/src/FSharpPlus/Seq.fs
@@ -1,6 +1,7 @@
 ﻿namespace FSharpPlus.Data
 
 open FSharpPlus
+open System.ComponentModel
 
 /// Additional operations on Seq
 module Seq =
@@ -32,25 +33,40 @@ module SeqT =
     let inline map  (f:'T->'U) (SeqT m : SeqT<'``Monad<seq<'T>``>)                                   = SeqT <| map (Seq.map f: (seq<_>->_)) m                   : SeqT<'``Monad<seq<'U>``>
 
 type SeqT<'``monad<seq<'t>>``> with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return (x : 'T) = x |> Seq.singleton |> result |> SeqT                                       : SeqT<'``Monad<seq<'T>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : SeqT<'``Monad<seq<'T>``>, f : 'T->'U) = SeqT.map f x                             : SeqT<'``Monad<seq<'U>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>)  (f : SeqT<'``Monad<seq<('T -> 'U)>``>, x : SeqT<'``Monad<seq<'T>``>) = SeqT.apply f x : SeqT<'``Monad<seq<'U>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (>>=)  (x : SeqT<'``Monad<seq<'T>``>, f : 'T -> SeqT<'``Monad<seq<'U>``>)   = SeqT.bind  f x
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Empty () = SeqT <| result Seq.empty : SeqT<'``MonadPlus<seq<'T>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<|>) (SeqT x , SeqT y) = SeqT <| (x >>= (fun a -> y >>= (fun b ->  result ((Seq.append:seq<_>->seq<_>->_) a b)))) : SeqT<'``MonadPlus<seq<'T>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (x:'``Monad<'T>``) = x |> liftM Seq.singleton |> SeqT : SeqT<'``Monad<seq<'T>>``>
     
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline LiftAsync (x : Async<'T>) = lift (liftAsync x) : '``SeqT<'MonadAsync<'T>>``
     
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Throw (x:'E) = x |> throw |> lift
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Catch (m:SeqT<'``MonadError<'E1,'T>``>, h:'E1 -> SeqT<'``MonadError<'E2,'T>``>) = SeqT ((fun v h -> catch v h) (SeqT.run m) (SeqT.run << h)) : SeqT<'``MonadError<'E2,'T>``>
     
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline CallCC (f:(('T -> SeqT<'``MonadCont<'R,seq<'U>>``>) -> _)) = SeqT (callCC <| fun c -> SeqT.run (f (SeqT  << c << Seq.singleton ))) : SeqT<'``MonadCont<'R, seq<'T>>``>
     
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Get()  = lift get                                          : '``SeqT<'MonadState<'S,'S>>``
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'T) = x |> put |> lift                                  : '``SeqT<'MonadState<unit,'S>>``
     
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Ask() = lift ask                                           : '``SeqT<'MonadReader<'R,seq<'R>>>``
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Local (SeqT (m:'``MonadReader<'R2,'T>``), f:'R1->'R2) = SeqT (local f m)

--- a/src/FSharpPlus/Seq.fs
+++ b/src/FSharpPlus/Seq.fs
@@ -37,14 +37,10 @@ type SeqT<'``monad<seq<'t>>``> with
     static member inline Return (x : 'T) = x |> Seq.singleton |> result |> SeqT                                       : SeqT<'``Monad<seq<'T>``>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : SeqT<'``Monad<seq<'T>``>, f : 'T->'U) = SeqT.map f x                             : SeqT<'``Monad<seq<'U>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>)  (f : SeqT<'``Monad<seq<('T -> 'U)>``>, x : SeqT<'``Monad<seq<'T>``>) = SeqT.apply f x : SeqT<'``Monad<seq<'U>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (>>=)  (x : SeqT<'``Monad<seq<'T>``>, f : 'T -> SeqT<'``Monad<seq<'U>``>)   = SeqT.bind  f x
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Empty () = SeqT <| result Seq.empty : SeqT<'``MonadPlus<seq<'T>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<|>) (SeqT x , SeqT y) = SeqT <| (x >>= (fun a -> y >>= (fun b ->  result ((Seq.append:seq<_>->seq<_>->_) a b)))) : SeqT<'``MonadPlus<seq<'T>``>
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
@@ -61,12 +57,10 @@ type SeqT<'``monad<seq<'t>>``> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline CallCC (f:(('T -> SeqT<'``MonadCont<'R,seq<'U>>``>) -> _)) = SeqT (callCC <| fun c -> SeqT.run (f (SeqT  << c << Seq.singleton ))) : SeqT<'``MonadCont<'R, seq<'T>>``>
     
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Get()  = lift get                                          : '``SeqT<'MonadState<'S,'S>>``
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'T) = x |> put |> lift                                  : '``SeqT<'MonadState<unit,'S>>``
     
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Ask() = lift ask                                           : '``SeqT<'MonadReader<'R,seq<'R>>>``
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Local (SeqT (m:'``MonadReader<'R2,'T>``), f:'R1->'R2) = SeqT (local f m)

--- a/src/FSharpPlus/Seq.fs
+++ b/src/FSharpPlus/Seq.fs
@@ -33,7 +33,6 @@ module SeqT =
     let inline map  (f:'T->'U) (SeqT m : SeqT<'``Monad<seq<'T>``>)                                   = SeqT <| map (Seq.map f: (seq<_>->_)) m                   : SeqT<'``Monad<seq<'U>``>
 
 type SeqT<'``monad<seq<'t>>``> with
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return (x : 'T) = x |> Seq.singleton |> result |> SeqT                                       : SeqT<'``Monad<seq<'T>``>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : SeqT<'``Monad<seq<'T>``>, f : 'T->'U) = SeqT.map f x                             : SeqT<'``Monad<seq<'U>``>
@@ -43,24 +42,17 @@ type SeqT<'``monad<seq<'t>>``> with
     static member inline get_Empty () = SeqT <| result Seq.empty : SeqT<'``MonadPlus<seq<'T>``>
     static member inline (<|>) (SeqT x , SeqT y) = SeqT <| (x >>= (fun a -> y >>= (fun b ->  result ((Seq.append:seq<_>->seq<_>->_) a b)))) : SeqT<'``MonadPlus<seq<'T>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (x:'``Monad<'T>``) = x |> liftM Seq.singleton |> SeqT : SeqT<'``Monad<seq<'T>>``>
     
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline LiftAsync (x : Async<'T>) = lift (liftAsync x) : '``SeqT<'MonadAsync<'T>>``
     
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Throw (x:'E) = x |> throw |> lift
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Catch (m:SeqT<'``MonadError<'E1,'T>``>, h:'E1 -> SeqT<'``MonadError<'E2,'T>``>) = SeqT ((fun v h -> catch v h) (SeqT.run m) (SeqT.run << h)) : SeqT<'``MonadError<'E2,'T>``>
     
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline CallCC (f:(('T -> SeqT<'``MonadCont<'R,seq<'U>>``>) -> _)) = SeqT (callCC <| fun c -> SeqT.run (f (SeqT  << c << Seq.singleton ))) : SeqT<'``MonadCont<'R, seq<'T>>``>
     
     static member inline get_Get()  = lift get                                          : '``SeqT<'MonadState<'S,'S>>``
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'T) = x |> put |> lift                                  : '``SeqT<'MonadState<unit,'S>>``
     
     static member inline get_Ask() = lift ask                                           : '``SeqT<'MonadReader<'R,seq<'R>>>``
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Local (SeqT (m:'``MonadReader<'R2,'T>``), f:'R1->'R2) = SeqT (local f m)

--- a/src/FSharpPlus/State.fs
+++ b/src/FSharpPlus/State.fs
@@ -29,11 +29,8 @@ type State<'s,'t> with
     static member Map   (x, f:'T->_) = State.map f x          : State<'S,'U>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return a = State (fun s -> (a, s))          : State<'S,'T>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (>>=) (x, f:'T->_) = State.bind f x         : State<'S,'U>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (<*>) (f, x:State<'S,'T>) = State.apply f x : State<'S,'U>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member get_Get() = State.get                       : State<'S,'S>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Put x     = State.put x                     : State<'S,unit>
@@ -58,14 +55,10 @@ type StateT<'s,'``monad<'t * 's>``> with
     static member inline Return (x : 'T) = StateT (fun s -> result (x, s))                                                         : StateT<'S,'``Monad<'T * 'S>``>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : StateT<'S,'``Monad<'T * 'S>``>, f : 'T->'U)                                = StateT.map   f x : StateT<'S,'``Monad<'U * 'S>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>)  (f : StateT<'S,'``Monad<('T -> 'U) * 'S>``>, x :StateT<'S,'``Monad<'T * 'S>``>) = StateT.apply f x : StateT<'S,'``Monad<'U * 'S>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (>>=)  (x : StateT<'S,'``Monad<'T * 'S>``>, f : 'T->StateT<'S,'``Monad<'U * 'S>``>)    = StateT.bind  f x
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Empty () = StateT (fun _ -> getEmpty()) : StateT<'S,'``MonadPlus<'T * 'S>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<|>) (StateT m, StateT n) = StateT (fun s -> m s <|> n s) : StateT<'S,'``MonadPlus<'T * 'S>``>
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
@@ -74,7 +67,6 @@ type StateT<'s,'``monad<'t * 's>``> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline LiftAsync (x :Async<'T>) = lift (liftAsync x) : '``StateT<'S,'MonadAsync<'T>>``
     
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Get () = StateT (fun s -> result (s , s))  : StateT<'S, '``Monad<'S * 'S>``>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'S) = StateT (fun _ -> result ((), x))  : StateT<'S, '``Monad<unit * 'S>``>

--- a/src/FSharpPlus/State.fs
+++ b/src/FSharpPlus/State.fs
@@ -27,7 +27,6 @@ module State =
 type State<'s,'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map   (x, f:'T->_) = State.map f x          : State<'S,'U>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return a = State (fun s -> (a, s))          : State<'S,'T>
     static member (>>=) (x, f:'T->_) = State.bind f x         : State<'S,'U>
     static member (<*>) (f, x:State<'S,'T>) = State.apply f x : State<'S,'U>
@@ -51,7 +50,6 @@ module StateT =
     let inline bind (f :'T->StateT<'S,'``Monad<'U * 'S>``>) (StateT m: StateT<'S,'``Monad<'T * 'S>``>) = StateT <| fun s -> m s >>= (fun (a, s') -> run (f a) s')
 
 type StateT<'s,'``monad<'t * 's>``> with
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return (x : 'T) = StateT (fun s -> result (x, s))                                                         : StateT<'S,'``Monad<'T * 'S>``>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : StateT<'S,'``Monad<'T * 'S>``>, f : 'T->'U)                                = StateT.map   f x : StateT<'S,'``Monad<'U * 'S>``>
@@ -61,23 +59,17 @@ type StateT<'s,'``monad<'t * 's>``> with
     static member inline get_Empty () = StateT (fun _ -> getEmpty()) : StateT<'S,'``MonadPlus<'T * 'S>``>
     static member inline (<|>) (StateT m, StateT n) = StateT (fun s -> m s <|> n s) : StateT<'S,'``MonadPlus<'T * 'S>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (m:'``Monad<'T>``) : StateT<'S,'``Monad<'T * 'S>``> = StateT <| fun s -> m >>= fun a -> result (a, s)
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline LiftAsync (x :Async<'T>) = lift (liftAsync x) : '``StateT<'S,'MonadAsync<'T>>``
     
     static member inline get_Get () = StateT (fun s -> result (s , s))  : StateT<'S, '``Monad<'S * 'S>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'S) = StateT (fun _ -> result ((), x))  : StateT<'S, '``Monad<unit * 'S>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Throw (x :'E) = x |> throw |> lift
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Catch (m :StateT<'S,'``MonadError<'E1,'T * 'S>``>, h:'E1 -> _) = 
         StateT (fun s -> catch (StateT.run m s) (fun e -> StateT.run (h e) s)) : StateT<'S,'``MonadError<'E2, 'T * 'S>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Delay (f: unit -> StateT<'S,'``Monad<'T * 'S>``>) =
         StateT (fun s ->
             let d () = StateT.run (f ()) s

--- a/src/FSharpPlus/State.fs
+++ b/src/FSharpPlus/State.fs
@@ -1,4 +1,5 @@
 ﻿namespace FSharpPlus.Data
+open System.ComponentModel
 
 /// <summary> Computation type: Computations which maintain state.
 /// <para/>   Binding strategy: Threads a state parameter through the sequence of bound functions so that the same state value is never used twice, giving the illusion of in-place update.
@@ -24,11 +25,17 @@ module State =
     let put x = State (fun _ -> ((), x))                                                                         : State<'S,unit>
 
 type State<'s,'t> with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map   (x, f:'T->_) = State.map f x          : State<'S,'U>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return a = State (fun s -> (a, s))          : State<'S,'T>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (>>=) (x, f:'T->_) = State.bind f x         : State<'S,'U>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (<*>) (f, x:State<'S,'T>) = State.apply f x : State<'S,'U>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member get_Get() = State.get                       : State<'S,'S>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Put x     = State.put x                     : State<'S,unit>
 
 open FSharpPlus.Control
@@ -47,25 +54,38 @@ module StateT =
     let inline bind (f :'T->StateT<'S,'``Monad<'U * 'S>``>) (StateT m: StateT<'S,'``Monad<'T * 'S>``>) = StateT <| fun s -> m s >>= (fun (a, s') -> run (f a) s')
 
 type StateT<'s,'``monad<'t * 's>``> with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return (x : 'T) = StateT (fun s -> result (x, s))                                                         : StateT<'S,'``Monad<'T * 'S>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : StateT<'S,'``Monad<'T * 'S>``>, f : 'T->'U)                                = StateT.map   f x : StateT<'S,'``Monad<'U * 'S>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>)  (f : StateT<'S,'``Monad<('T -> 'U) * 'S>``>, x :StateT<'S,'``Monad<'T * 'S>``>) = StateT.apply f x : StateT<'S,'``Monad<'U * 'S>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (>>=)  (x : StateT<'S,'``Monad<'T * 'S>``>, f : 'T->StateT<'S,'``Monad<'U * 'S>``>)    = StateT.bind  f x
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Empty () = StateT (fun _ -> getEmpty()) : StateT<'S,'``MonadPlus<'T * 'S>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<|>) (StateT m, StateT n) = StateT (fun s -> m s <|> n s) : StateT<'S,'``MonadPlus<'T * 'S>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (m:'``Monad<'T>``) : StateT<'S,'``Monad<'T * 'S>``> = StateT <| fun s -> m >>= fun a -> result (a, s)
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline LiftAsync (x :Async<'T>) = lift (liftAsync x) : '``StateT<'S,'MonadAsync<'T>>``
     
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Get () = StateT (fun s -> result (s , s))  : StateT<'S, '``Monad<'S * 'S>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'S) = StateT (fun _ -> result ((), x))  : StateT<'S, '``Monad<unit * 'S>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Throw (x :'E) = x |> throw |> lift
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Catch (m :StateT<'S,'``MonadError<'E1,'T * 'S>``>, h:'E1 -> _) = 
         StateT (fun s -> catch (StateT.run m s) (fun e -> StateT.run (h e) s)) : StateT<'S,'``MonadError<'E2, 'T * 'S>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Delay (f: unit -> StateT<'S,'``Monad<'T * 'S>``>) =
         StateT (fun s ->
             let d () = StateT.run (f ()) s

--- a/src/FSharpPlus/Writer.fs
+++ b/src/FSharpPlus/Writer.fs
@@ -36,19 +36,14 @@ module Writer =
 type Writer<'monoid,'t> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        Map   (x, f:'T->_) = Writer.map f x          : Writer<'Monoid,'U>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return x = Writer (x, getZero ())            : Writer<'Monoid,'T>
     static member inline (>>=) (x, f:'T->_) = Writer.bind f x         : Writer<'Monoid,'U>
     static member inline (<*>) (f, x:Writer<_,'T>) = Writer.apply f x : Writer<'Monoid,'U>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        Tell   w = Writer.tell w                     : Writer<'Monoid,unit>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        Listen m = Writer.listen m                   : Writer<'Monoid,('T * 'Monoid)>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        Pass   m = Writer.pass m                     : Writer<'Monoid,'T>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        Extract (Writer (_ : 'W, a : 'T)) = a
     static member        (=>>)   (Writer (w : 'W, _ : 'T) as g, f : Writer<_,_> -> 'U) = Writer (w, f g)
 

--- a/src/FSharpPlus/Writer.fs
+++ b/src/FSharpPlus/Writer.fs
@@ -1,5 +1,5 @@
 ﻿namespace FSharpPlus.Data
-
+open System.ComponentModel
 /// <summary> Computation type: Computations which produce a stream of data in addition to the computed values.
 /// <para/>   Binding strategy: Combines the outputs of the subcomputations using <c>mappend</c>.
 /// <para/>   Useful for: Logging, or other computations that produce output "on the side". </summary>
@@ -34,16 +34,25 @@ module Writer =
     let pass m = let (Writer((a, f), w:'Monoid)) = m in Writer(a, f w)                       : Writer<'Monoid,'T>
 
 type Writer<'monoid,'t> with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        Map   (x, f:'T->_) = Writer.map f x          : Writer<'Monoid,'U>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return x = Writer (x, getZero ())            : Writer<'Monoid,'T>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (>>=) (x, f:'T->_) = Writer.bind f x         : Writer<'Monoid,'U>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>) (f, x:Writer<_,'T>) = Writer.apply f x : Writer<'Monoid,'U>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        Tell   w = Writer.tell w                     : Writer<'Monoid,unit>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        Listen m = Writer.listen m                   : Writer<'Monoid,('T * 'Monoid)>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        Pass   m = Writer.pass m                     : Writer<'Monoid,'T>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        Extract (Writer (_ : 'W, a : 'T)) = a
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        (=>>)   (Writer (w : 'W, _ : 'T) as g, f : Writer<_,_> -> 'U) = Writer (w, f g)
 
 open FSharpPlus.Control
@@ -72,31 +81,49 @@ module WriterT =
 
 type WriterT<'``monad<'t * 'monoid>``> with
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return (x : 'T) = WriterT (result (x, getZero ()))                                                                 : WriterT<'``Monad<'T * 'Monoid>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : WriterT<'``Monad<'T * 'Monoid>``>, f : 'T -> 'U)                                   = WriterT.map   f x : WriterT<'``Monad<'U * 'Monoid>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>)  (f : WriterT<'``Monad<('T -> 'U) * 'Monoid>``>, x : WriterT<'``Monad<'T * 'Monoid>``>)  = WriterT.apply f x : WriterT<'``Monad<'U * 'Monoid>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (>>=)  (x : WriterT<'``Monad<'T * 'Monoid>``>, f :'T -> _)                                     = WriterT.bind  f x : WriterT<'``Monad<'U * 'Monoid>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Empty () = WriterT (getEmpty()) : WriterT<'``MonadPlus<'T * 'Monoid>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<|>) (WriterT m, WriterT n) = WriterT (m <|> n) : WriterT<'``MonadPlus<'T * 'Monoid>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Tell   (w:'Monoid) = WriterT (result ((), w))                                                                                         : WriterT<'``Monad<unit * 'Monoid>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Listen (WriterT m: WriterT<'``Monad<('T * ('Monoid'T -> 'Monoid)) * 'Monoid>``>) = WriterT (m >>= (fun (a, w) -> result ((a, w), w))) : WriterT<'``Monad<('T * 'Monoid) * 'Monoid>``>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Pass   (WriterT m: WriterT<'``Monad<'T * 'Monoid>``>) = WriterT (m >>= (fun ((a, f), w) -> result (a, f w)))                          : WriterT<'``Monad<'T * 'Monoid>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (m:'``Monad<'T>``) : WriterT<'``Monad<'T * 'Monoid>``> = WriterT (m >>= (fun a -> result (a, getZero ())))
     
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline LiftAsync (x: Async<'T>) = lift (liftAsync x) : '``WriterT<'MonadAsync<'T>>``
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Throw (x: 'E) = x |> throw |> lift
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Catch (m:WriterT<'``MonadError<'E2, 'T * 'Monoid>``> , h:'E2 -> _) = 
             WriterT (catch (WriterT.run m) (WriterT.run << h)) : WriterT<'``MonadChoice<'T * 'Monoid, 'E2>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline CallCC (f : ('a->WriterT<Cont<'r,'t>>)->_)  : WriterT<'``MonadCont<'r,'a*'b>``> = 
         WriterT (callCC <| fun c -> WriterT.run (f (fun a -> WriterT <| c (a, getZero ()))))
        
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Ask ()                    = lift ask            : '``WriterT<'MonadReader<'R,'R*'Monoid>>``
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Local (WriterT m, f:'R1->'R2) = WriterT (local f m) : WriterT<'``MonadReader<'R1,'T*'Monoid>``>
 
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Get () = lift get         : '``WriterT<'MonadState<'S,'S*'Monoid>>``
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'S) = x |> put |> lift : '``WriterT<'MonadState<'S,unit*'Monoid>>``

--- a/src/FSharpPlus/Writer.fs
+++ b/src/FSharpPlus/Writer.fs
@@ -78,7 +78,6 @@ module WriterT =
 
 type WriterT<'``monad<'t * 'monoid>``> with
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return (x : 'T) = WriterT (result (x, getZero ()))                                                                 : WriterT<'``Monad<'T * 'Monoid>``>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : WriterT<'``Monad<'T * 'Monoid>``>, f : 'T -> 'U)                                   = WriterT.map   f x : WriterT<'``Monad<'U * 'Monoid>``>
@@ -88,33 +87,23 @@ type WriterT<'``monad<'t * 'monoid>``> with
     static member inline get_Empty () = WriterT (getEmpty()) : WriterT<'``MonadPlus<'T * 'Monoid>``>
     static member inline (<|>) (WriterT m, WriterT n) = WriterT (m <|> n) : WriterT<'``MonadPlus<'T * 'Monoid>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Tell   (w:'Monoid) = WriterT (result ((), w))                                                                                         : WriterT<'``Monad<unit * 'Monoid>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Listen (WriterT m: WriterT<'``Monad<('T * ('Monoid'T -> 'Monoid)) * 'Monoid>``>) = WriterT (m >>= (fun (a, w) -> result ((a, w), w))) : WriterT<'``Monad<('T * 'Monoid) * 'Monoid>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Pass   (WriterT m: WriterT<'``Monad<'T * 'Monoid>``>) = WriterT (m >>= (fun ((a, f), w) -> result (a, f w)))                          : WriterT<'``Monad<'T * 'Monoid>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Lift (m:'``Monad<'T>``) : WriterT<'``Monad<'T * 'Monoid>``> = WriterT (m >>= (fun a -> result (a, getZero ())))
     
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline LiftAsync (x: Async<'T>) = lift (liftAsync x) : '``WriterT<'MonadAsync<'T>>``
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Throw (x: 'E) = x |> throw |> lift
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Catch (m:WriterT<'``MonadError<'E2, 'T * 'Monoid>``> , h:'E2 -> _) = 
             WriterT (catch (WriterT.run m) (WriterT.run << h)) : WriterT<'``MonadChoice<'T * 'Monoid, 'E2>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline CallCC (f : ('a->WriterT<Cont<'r,'t>>)->_)  : WriterT<'``MonadCont<'r,'a*'b>``> = 
         WriterT (callCC <| fun c -> WriterT.run (f (fun a -> WriterT <| c (a, getZero ()))))
        
     static member inline get_Ask ()                    = lift ask            : '``WriterT<'MonadReader<'R,'R*'Monoid>>``
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Local (WriterT m, f:'R1->'R2) = WriterT (local f m) : WriterT<'``MonadReader<'R1,'T*'Monoid>``>
 
     static member inline get_Get () = lift get         : '``WriterT<'MonadState<'S,'S*'Monoid>>``
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'S) = x |> put |> lift : '``WriterT<'MonadState<'S,unit*'Monoid>>``

--- a/src/FSharpPlus/Writer.fs
+++ b/src/FSharpPlus/Writer.fs
@@ -38,9 +38,7 @@ type Writer<'monoid,'t> with
     static member        Map   (x, f:'T->_) = Writer.map f x          : Writer<'Monoid,'U>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Return x = Writer (x, getZero ())            : Writer<'Monoid,'T>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (>>=) (x, f:'T->_) = Writer.bind f x         : Writer<'Monoid,'U>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>) (f, x:Writer<_,'T>) = Writer.apply f x : Writer<'Monoid,'U>
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
@@ -52,7 +50,6 @@ type Writer<'monoid,'t> with
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        Extract (Writer (_ : 'W, a : 'T)) = a
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member        (=>>)   (Writer (w : 'W, _ : 'T) as g, f : Writer<_,_> -> 'U) = Writer (w, f g)
 
 open FSharpPlus.Control
@@ -85,14 +82,10 @@ type WriterT<'``monad<'t * 'monoid>``> with
     static member inline Return (x : 'T) = WriterT (result (x, getZero ()))                                                                 : WriterT<'``Monad<'T * 'Monoid>``>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Map    (x : WriterT<'``Monad<'T * 'Monoid>``>, f : 'T -> 'U)                                   = WriterT.map   f x : WriterT<'``Monad<'U * 'Monoid>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<*>)  (f : WriterT<'``Monad<('T -> 'U) * 'Monoid>``>, x : WriterT<'``Monad<'T * 'Monoid>``>)  = WriterT.apply f x : WriterT<'``Monad<'U * 'Monoid>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (>>=)  (x : WriterT<'``Monad<'T * 'Monoid>``>, f :'T -> _)                                     = WriterT.bind  f x : WriterT<'``Monad<'U * 'Monoid>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Empty () = WriterT (getEmpty()) : WriterT<'``MonadPlus<'T * 'Monoid>``>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (<|>) (WriterT m, WriterT n) = WriterT (m <|> n) : WriterT<'``MonadPlus<'T * 'Monoid>``>
 
     [<EditorBrowsable(EditorBrowsableState.Never)>]
@@ -118,12 +111,10 @@ type WriterT<'``monad<'t * 'monoid>``> with
     static member inline CallCC (f : ('a->WriterT<Cont<'r,'t>>)->_)  : WriterT<'``MonadCont<'r,'a*'b>``> = 
         WriterT (callCC <| fun c -> WriterT.run (f (fun a -> WriterT <| c (a, getZero ()))))
        
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Ask ()                    = lift ask            : '``WriterT<'MonadReader<'R,'R*'Monoid>>``
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Local (WriterT m, f:'R1->'R2) = WriterT (local f m) : WriterT<'``MonadReader<'R1,'T*'Monoid>``>
 
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Get () = lift get         : '``WriterT<'MonadState<'S,'S*'Monoid>>``
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline Put (x:'S) = x |> put |> lift : '``WriterT<'MonadState<'S,unit*'Monoid>>``

--- a/src/FSharpPlus/ZipList.fs
+++ b/src/FSharpPlus/ZipList.fs
@@ -21,14 +21,11 @@ module ZipList =
 type ZipList<'s> with
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map (ZipList x, f:'a->'b) = ZipList (Seq.map f x)
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return (x:'a)     = ZipList (Seq.initInfinite (konst x))
     static member (<*>) (ZipList (f:seq<'a->'b>), ZipList x) = ZipList (Seq.zip f x |> Seq.map (fun (f, x) -> f x)) : ZipList<'b>
     static member inline get_Zero() = result (getZero()) : ZipList<'a>
     static member inline (+) (x:ZipList<'a>, y:ZipList<'a>) = liftA2 plus x y : ZipList<'a>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member ToSeq (ZipList x) = x
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
 
     static member inline Traverse (ZipList (x:seq<'T>), f:'T->'``Functor<'U>``) =
         let lst = traverse f x : '``Functor<List<'U>>``

--- a/src/FSharpPlus/ZipList.fs
+++ b/src/FSharpPlus/ZipList.fs
@@ -23,11 +23,8 @@ type ZipList<'s> with
     static member Map (ZipList x, f:'a->'b) = ZipList (Seq.map f x)
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return (x:'a)     = ZipList (Seq.initInfinite (konst x))
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (<*>) (ZipList (f:seq<'a->'b>), ZipList x) = ZipList (Seq.zip f x |> Seq.map (fun (f, x) -> f x)) : ZipList<'b>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Zero() = result (getZero()) : ZipList<'a>
-    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (+) (x:ZipList<'a>, y:ZipList<'a>) = liftA2 plus x y : ZipList<'a>
     [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member ToSeq (ZipList x) = x

--- a/src/FSharpPlus/ZipList.fs
+++ b/src/FSharpPlus/ZipList.fs
@@ -4,6 +4,7 @@ open System.Text
 open System.Runtime.InteropServices
 open FSharpPlus
 open FSharpPlus.Control
+open System.ComponentModel
 
 /// A sequence with an Applicative functor based on zipping.
 [<NoComparison>]
@@ -18,12 +19,19 @@ module ZipList =
     let singleton x = ZipList (Seq.singleton x)
 
 type ZipList<'s> with
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Map (ZipList x, f:'a->'b) = ZipList (Seq.map f x)
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member Return (x:'a)     = ZipList (Seq.initInfinite (konst x))
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member (<*>) (ZipList (f:seq<'a->'b>), ZipList x) = ZipList (Seq.zip f x |> Seq.map (fun (f, x) -> f x)) : ZipList<'b>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline get_Zero() = result (getZero()) : ZipList<'a>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member inline (+) (x:ZipList<'a>, y:ZipList<'a>) = liftA2 plus x y : ZipList<'a>
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     static member ToSeq (ZipList x) = x
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
 
     static member inline Traverse (ZipList (x:seq<'T>), f:'T->'``Functor<'U>``) =
         let lst = traverse f x : '``Functor<List<'U>>``


### PR DESCRIPTION
I've applied `[<EditorBrowsable(EditorBrowsableState.Never)>]` to the below types in case where you might use the explicit type name in order to operate on data.
- `DList`, `ZipList`, `ParallelArray`, `NonEmptyList`

- `ResultT`
- `ContT`
- `OptionT`
- `Reader`, `ReaderT`
- `SeqT`
- `State`, `StateT`
- `Writer`, `WriterT`

See https://github.com/gusty/FSharpPlus/issues/84#issuecomment-372952783