### PR TITLE
Exceptions and AggregateExceptions as Semigroup

### DIFF
--- a/src/FSharpPlus/Monoid.fs
+++ b/src/FSharpPlus/Monoid.fs
@@ -25,7 +25,10 @@ type Plus =
     static member        ``+`` (x:Set<_>       , y                    , [<Optional>]_mthd : Plus    ) = Set.union x y
     static member        ``+`` (x:StringBuilder, y:StringBuilder      , [<Optional>]_mthd : Plus    ) = StringBuilder().Append(x).Append(y)    
     static member        ``+`` (x:AggregateException, y:AggregateException, [<Optional>]_mthd : Plus    ) = new AggregateException (seq {yield! x.InnerExceptions; yield! y.InnerExceptions})
-    static member        ``+`` (_:Id0               , _:Id0               , [<Optional>]_mthd : Plus    ) = Id0 ""
+    static member        ``+`` (_:Id0               , _:Id0               , [<Optional>]_mthd : Plus    ) = Id0 ""    
+    static member        ``+`` (x:exn               , y:exn               , [<Optional>]_mthd : Plus    ) =
+        let f (e:exn) = match e with :? AggregateException as a -> a.InnerExceptions :> seq<_> | _ -> Seq.singleton e
+        new AggregateException (seq {yield! f x; yield! f y}) :> exn
 
     static member inline Invoke (x:'Plus) (y:'Plus)  : 'Plus =
         let inline call (mthd : ^M, input1 : ^I, input2 : ^I) = ((^M or ^I) : (static member ``+``: _*_*_ -> _) input1, input2, mthd)

--- a/src/FSharpPlus/Monoid.fs
+++ b/src/FSharpPlus/Monoid.fs
@@ -23,7 +23,9 @@ type Plus =
     static member        ``+`` (x:array<_>     , y                    , [<Optional>]_mthd : Plus    ) = Array.append x y
     static member        ``+`` (()             , ()                   , [<Optional>]_mthd : Plus    ) = ()
     static member        ``+`` (x:Set<_>       , y                    , [<Optional>]_mthd : Plus    ) = Set.union x y
-    static member        ``+`` (x:StringBuilder, y:StringBuilder      , [<Optional>]_mthd : Plus    ) = StringBuilder().Append(x).Append(y)
+    static member        ``+`` (x:StringBuilder, y:StringBuilder      , [<Optional>]_mthd : Plus    ) = StringBuilder().Append(x).Append(y)    
+    static member        ``+`` (x:AggregateException, y:AggregateException, [<Optional>]_mthd : Plus    ) = new AggregateException (seq {yield! x.InnerExceptions; yield! y.InnerExceptions})
+    static member        ``+`` (_:Id0               , _:Id0               , [<Optional>]_mthd : Plus    ) = Id0 ""
 
     static member inline Invoke (x:'Plus) (y:'Plus)  : 'Plus =
         let inline call (mthd : ^M, input1 : ^I, input2 : ^I) = ((^M or ^I) : (static member ``+``: _*_*_ -> _) input1, input2, mthd)

--- a/tests/FSharpPlus.Tests/Validations.fs
+++ b/tests/FSharpPlus.Tests/Validations.fs
@@ -278,4 +278,16 @@ module Tests=
     let expected = Failure three
     areEqual expected subject
 
- 
+  [<Test>]
+  let testValidateWithExceptions () = 
+    let subject = 
+        fun a b c d -> a + b + c + d
+        <!> Failure (exn "Failure receiving first parameter") 
+        <*> Success 4 
+        <*> Failure (exn "Failure receiving third parameter") 
+        <*> Failure (exn "Failure receiving last parameter")
+    let expected : Validation<exn,int> = Failure ((new AggregateException ([exn "Failure receiving first parameter"; exn "Failure receiving third parameter"; exn "Failure receiving last parameter"])) :> exn)
+    let f = function
+        | Success _ -> failwith "unexpected"
+        | Failure (e: exn) -> (e :?> AggregateException).InnerExceptions |> Seq.map (fun x -> x.Message) |> toList
+    areEqual (f subject) (f expected)


### PR DESCRIPTION
This could be very convenient for accumulative Validations and possible to alternative validation if we decide to define them as requiring a semigroup on the error parameter.